### PR TITLE
Replaced deprecated mimetype argument with content_type in HttpResponses

### DIFF
--- a/assetpipe/outputters/blobstore.py
+++ b/assetpipe/outputters/blobstore.py
@@ -86,4 +86,4 @@ class Blobstore(Outputter):
             return HttpResponseNotFound()
             #
         content = BlobReader(info.key()).read()
-        return HttpResponse(content, mimetype=info.content_type)
+        return HttpResponse(content, content_type=info.content_type)

--- a/assetpipe/outputters/filesystem.py
+++ b/assetpipe/outputters/filesystem.py
@@ -53,4 +53,4 @@ class Filesystem(Outputter):
 
         content = open(filename, "r").read()
 
-        return HttpResponse(content, mimetype=mimetype)
+        return HttpResponse(content, content_type=mimetype)


### PR DESCRIPTION
`mimetype` argument in HttpResponse was deprecated and then removed in Django 1.7. This PR updates it to content_type (compatible with Django 1.4, 1.5, 1.6, 1.7 and 1.8 ;))